### PR TITLE
Fixed issue with Zymo naming standard

### DIFF
--- a/figaro.py
+++ b/figaro.py
@@ -26,7 +26,7 @@ def getApplicationParameters():
         if character not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_.-":
             raise ValueError("Unusual character detected for output file name.  Contains %s" %character)
     if parameters.subsample.value == -1:
-        totalFileSize = figaroSupport.fastqAnalysis.getEstimatedFastqSizeSumFromDirectory(parameters.inputDirectory.value)
+        totalFileSize = figaroSupport.fastqAnalysis.getEstimatedFastqSizeSumFromDirectory(parameters.inputDirectory.value, parameters.fileNamingStandard.value)
         fastqGigabytes = totalFileSize / 1000000000
         parameters.subsample.value = round(fastqGigabytes * 10)
     return parameters
@@ -73,7 +73,7 @@ def getApplicationParametersFromCommandLine():
         raise ValueError("Minimum overlap must be a positive integer. %s was given." %minimumOverlap)
     subsample = args.subsample
     if subsample < 0:
-        totalFileSize = figaroSupport.fastqAnalysis.getEstimatedFastqSizeSumFromDirectory(inputDirectory)
+        totalFileSize = figaroSupport.fastqAnalysis.getEstimatedFastqSizeSumFromDirectory(inputDirectory, fileNamingStandard)
         fastqGigabytes = totalFileSize / 1000000000
         subsample = round(fastqGigabytes * 10)
     percentile = args.percentile

--- a/figaroSupport/fastqAnalysis.py
+++ b/figaroSupport/fastqAnalysis.py
@@ -100,10 +100,12 @@ def getEstimatedFastqFileSizeSumFromList(fastqList:list):
         sum += fileSize
     return sum
 
-def getEstimatedFastqSizeSumFromDirectory(path:str):
+def getEstimatedFastqSizeSumFromDirectory(path:str, fileNamingStandardAlias:str):
     import os
+    from . import fileNamingStandards
     from . import fastqHandler
+    fileNamingStandard = fileNamingStandards.loadNamingStandard(fileNamingStandardAlias)
     if not os.path.isdir(path):
         raise NotADirectoryError("Unable to find a directory at %s" %path)
-    fastqList = fastqHandler.findSamplesInFolder(path)
+    fastqList = fastqHandler.findSamplesInFolder(path, fileNamingStandard)
     return getEstimatedFastqFileSizeSumFromList(fastqList)

--- a/figaroSupport/fileNamingStandards.py
+++ b/figaroSupport/fileNamingStandards.py
@@ -60,12 +60,15 @@ class ZymoServicesNamingStandard(NamingStandard):
 class IlluminaStandard(NamingStandard):
 
     def getSampleInfo(self, fileName:str):
-        baseName = fileName.split(".")[0]
-        baseSplit = baseName.split("_")
-        group = "_".join(baseSplit[:-4])
-        sample = int(baseSplit[-4].replace("S",""))
-        direction = int(baseSplit[-2].replace("R",""))
-        return group, sample, direction
+        try:
+            baseName = fileName.split(".")[0]
+            baseSplit = baseName.split("_")
+            group = "_".join(baseSplit[:-4])
+            sample = int(baseSplit[-4].replace("S",""))
+            direction = int(baseSplit[-2].replace("R",""))
+            return group, sample, direction
+        except (ValueError, IndexError):
+            raise ValueError("%s does not appear to be a valid Illumina file name. Please check file naming convention argument." % fileName)
 
 
 class ManualNamingStandard(NamingStandard):


### PR DESCRIPTION
Fixed issue where zymo naming standard files fail during the initial estimation of data size.  Naming standard preferences were not being passed successfully to this function.  This has been fixed.