### PR TITLE
Fixed variance calculation crash

### DIFF
--- a/figaroSupport/fastqHandler.py
+++ b/figaroSupport/fastqHandler.py
@@ -457,7 +457,10 @@ def estimateReadLength(path:str, samplesize:int=100, getVariance = False):
     meanReadLength = sum(lengths)/len(lengths)
     if getVariance:
         import statistics
-        lengthVariance = statistics.variance(lengths)
+        if len(lengths) > 1:
+            lengthVariance = statistics.variance(lengths)
+        else:
+            lengthVariance = 0
         return round(meanReadLength), lengthVariance
     return round(meanReadLength)
 


### PR DESCRIPTION
Fixed the issue causing the crash when a fastq of length 1 was in the sample (although you really should look into why it was there).