### PR TITLE
change match "Rx.fastq" to "Rx_001.fastq"

### DIFF
--- a/figaro/fileNamingStandards.py
+++ b/figaro/fileNamingStandards.py
@@ -54,7 +54,7 @@ class NoNonsenseNamingStandard(NamingStandard):
     def getSampleInfo(self, fileName:str):
         import re
         import os
-        baseName = re.sub("\.(fq|fastq)(.gz)?$", "", os.path.basename(fileName))
+        baseName = re.sub("\._001.(fq|fastq)(.gz)?$", "", os.path.basename(fileName))
         direction = re.search("_R?[12]$", baseName)
         if not direction:
             raise ValueError("Could not infer read orientation from filename: {}".format(fileName))

--- a/figaro/fileNamingStandards.py
+++ b/figaro/fileNamingStandards.py
@@ -5,8 +5,8 @@ aliasList = {"zymo": "zymo",
              "illumina": "illumina",
              "keriksson": "keriksson",
              "nononsense": "nononsense"}
-             "fvieira": "fvieira",
-             "yzhang": "yzhang"}
+            # "fvieira": "fvieira",
+            # "yzhang": "yzhang"}
 
 class NamingStandard(object):
 
@@ -156,8 +156,8 @@ def loadNamingStandard(name:str):
                       "illumina" : IlluminaStandard,
                       "keriksson": KErickssonStandard,
                       "nononsense": NoNonsenseNamingStandard}
-                      "fvieira": FVieiraStandard,
-                      "yzhang": YZhangStandard}
+                    #  "fvieira": FVieiraStandard,
+                    #  "yzhang": YZhangStandard}
     nameLower = name.lower()
     if not nameLower in aliasList:
         raise ValueError("%s is not a valid naming standard identifier" %name)


### PR DESCRIPTION
Greets,

Not sure if this is the desired fix for this, but query is missing the standard "001" at the end, throwing the "Could not infer read orientation from filename" error. Thanks for the work!

> added terminal _001 to filename, as per Data\Intensities\BaseCalls\SampleName_S1_L001_R1_001.fastq.gz