### PR TITLE
Fix dictionaries

### DIFF
--- a/figaro/fileNamingStandards.py
+++ b/figaro/fileNamingStandards.py
@@ -4,7 +4,7 @@ aliasList = {"zymo": "zymo",
              "zymoservices": "zymo",
              "illumina": "illumina",
              "keriksson": "keriksson",
-             "nononsense": "nononsense"}
+             "nononsense": "nononsense",
              "fvieira": "fvieira",
              "yzhang": "yzhang"}
 
@@ -155,7 +155,7 @@ def loadNamingStandard(name:str):
     aliasObjectKey = {"zymo" : ZymoServicesNamingStandard,
                       "illumina" : IlluminaStandard,
                       "keriksson": KErickssonStandard,
-                      "nononsense": NoNonsenseNamingStandard}
+                      "nononsense": NoNonsenseNamingStandard,
                       "fvieira": FVieiraStandard,
                       "yzhang": YZhangStandard}
     nameLower = name.lower()


### PR DESCRIPTION
Curly brackets ended dictionaries to early leading to IndentationError when importing figaro.

The bug probably happened during the merge 25 days ago. With the changes the import works again.